### PR TITLE
fix: create base admin model mixin to all admin sites

### DIFF
--- a/src/bookkeeper_checklist_project/assistant/admin.py
+++ b/src/bookkeeper_checklist_project/assistant/admin.py
@@ -1,7 +1,9 @@
+from core.admin import BaseAdminModelMixin
 from django.contrib import admin
+
 from .models import Assistant
 
 
 @admin.register(Assistant)
-class AssistantAdmin(admin.ModelAdmin):
+class AssistantAdmin(BaseAdminModelMixin):
     pass

--- a/src/bookkeeper_checklist_project/bank_account/admin.py
+++ b/src/bookkeeper_checklist_project/bank_account/admin.py
@@ -1,17 +1,20 @@
+from core.admin import BaseAdminModelMixin
 from django.contrib import admin
+
 from .models import BankAccountItem, BankProfile, BankUserAccount
+
 
 # Register your models here.
 @admin.register(BankProfile)
-class BankProfileAdmin(admin.ModelAdmin):
+class BankProfileAdmin(BaseAdminModelMixin):
     pass
 
 
 @admin.register(BankUserAccount)
-class BankUserAccountAdmin(admin.ModelAdmin):
+class BankUserAccountAdmin(BaseAdminModelMixin):
     pass
 
 
 @admin.register(BankAccountItem)
-class BankAccountItemAdmin(admin.ModelAdmin):
+class BankAccountItemAdmin(BaseAdminModelMixin):
     pass

--- a/src/bookkeeper_checklist_project/bookkeeper/admin.py
+++ b/src/bookkeeper_checklist_project/bookkeeper/admin.py
@@ -1,7 +1,10 @@
+from core.admin import BaseAdminModelMixin
 from django.contrib import admin
+
 from .models import Bookkeeper
+
 
 # Register your models here.
 @admin.register(Bookkeeper)
-class BookkeeperAdmin(admin.ModelAdmin):
-    exclude = ("metadata",)
+class BookkeeperAdmin(BaseAdminModelMixin):
+    pass

--- a/src/bookkeeper_checklist_project/client/admin.py
+++ b/src/bookkeeper_checklist_project/client/admin.py
@@ -1,17 +1,18 @@
 from django.contrib import admin
+from core.admin import BaseAdminModelMixin
 from .models import Client, ClientAccount, ImportantContact
 
 
 @admin.register(Client)
-class ClientAdmin(admin.ModelAdmin):
+class ClientAdmin(BaseAdminModelMixin):
     pass
 
 
 @admin.register(ClientAccount)
-class ClientAccountAdmin(admin.ModelAdmin):
+class ClientAccountAdmin(BaseAdminModelMixin):
     pass
 
 
 @admin.register(ImportantContact)
-class ImportantContactAdmin(admin.ModelAdmin):
+class ImportantContactAdmin(BaseAdminModelMixin):
     pass

--- a/src/bookkeeper_checklist_project/company_services/admin.py
+++ b/src/bookkeeper_checklist_project/company_services/admin.py
@@ -1,7 +1,9 @@
+from core.admin import BaseAdminModelMixin
 from django.contrib import admin
+
 from .models import CompanyService
 
 
 @admin.register(CompanyService)
-class CompanyServiceAdmin(admin.ModelAdmin):
+class CompanyServiceAdmin(BaseAdminModelMixin):
     pass

--- a/src/bookkeeper_checklist_project/core/admin.py
+++ b/src/bookkeeper_checklist_project/core/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/src/bookkeeper_checklist_project/core/admin/__init__.py
+++ b/src/bookkeeper_checklist_project/core/admin/__init__.py
@@ -1,0 +1,1 @@
+from .mixin import BaseAdminModelMixin

--- a/src/bookkeeper_checklist_project/core/admin/mixin.py
+++ b/src/bookkeeper_checklist_project/core/admin/mixin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+
+class BaseAdminModelMixin(admin.ModelAdmin):
+    exclude = ("metadata",)

--- a/src/bookkeeper_checklist_project/jobs/admin.py
+++ b/src/bookkeeper_checklist_project/jobs/admin.py
@@ -1,7 +1,9 @@
+from core.admin import BaseAdminModelMixin
 from django.contrib import admin
+
 from .models import Job
 
 
 @admin.register(Job)
-class JobAdmin(admin.ModelAdmin):
-    exclude = ("metadata",)
+class JobAdmin(BaseAdminModelMixin):
+    pass

--- a/src/bookkeeper_checklist_project/manager/admin.py
+++ b/src/bookkeeper_checklist_project/manager/admin.py
@@ -1,3 +1,4 @@
+from core.admin import BaseAdminModelMixin
 from django.contrib import admin
 
 # Register your models here.

--- a/src/bookkeeper_checklist_project/notes/admin.py
+++ b/src/bookkeeper_checklist_project/notes/admin.py
@@ -1,7 +1,9 @@
+from core.admin import BaseAdminModelMixin
 from django.contrib import admin
+
 from .models import Note
 
 
 @admin.register(Note)
-class NoteAdmin(admin.ModelAdmin):
+class NoteAdmin(BaseAdminModelMixin):
     pass

--- a/src/bookkeeper_checklist_project/task/admin.py
+++ b/src/bookkeeper_checklist_project/task/admin.py
@@ -1,7 +1,9 @@
+from core.admin import BaseAdminModelMixin
 from django.contrib import admin
+
 from .models import Task
 
 
 @admin.register(Task)
-class TaskAdmin(admin.ModelAdmin):
+class TaskAdmin(BaseAdminModelMixin):
     pass

--- a/src/bookkeeper_checklist_project/users/admin.py
+++ b/src/bookkeeper_checklist_project/users/admin.py
@@ -1,3 +1,4 @@
+from core.admin import BaseAdminModelMixin
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import Permission
@@ -6,10 +7,10 @@ from .models import CustomUser
 
 
 @admin.register(Permission)
-class PermissionAdmin(admin.ModelAdmin):
+class PermissionAdmin(BaseAdminModelMixin):
     pass
 
 
 @admin.register(CustomUser)
-class CustomUserAdmin(admin.ModelAdmin):
-    list_filter = ('user_type', "created_at", "updated_at", "is_active")
+class CustomUserAdmin(BaseAdminModelMixin):
+    list_filter = ("user_type", "created_at", "updated_at", "is_active")


### PR DESCRIPTION
Add new feature, and create an admin model mixin for any model that will be used in the admin site.